### PR TITLE
Add is_final_step under processing/training/lambda/function step 

### DIFF
--- a/src/sagemaker/workflow/function_step.py
+++ b/src/sagemaker/workflow/function_step.py
@@ -67,6 +67,7 @@ class _FunctionStep(ConfigurableRetryStep):
         func: Callable = None,
         func_args: tuple = (),
         func_kwargs: dict = None,
+        is_final_step: Optional[bool] = False,
         **kwargs,
     ):
         """Constructs a _FunctionStep
@@ -96,6 +97,8 @@ class _FunctionStep(ConfigurableRetryStep):
         self._func = func
         self._func_args = func_args
         self._func_kwargs = func_kwargs if func_kwargs is not None else dict()
+
+        self.is_final_step = is_final_step
 
         self._step_kwargs = kwargs
 
@@ -225,6 +228,10 @@ class _FunctionStep(ConfigurableRetryStep):
     def to_request(self) -> RequestType:
         """Gets the request structure for workflow service calls."""
         request_dict = super().to_request()
+
+        if self.is_final_step:
+            request_dict.update({"IsFinalStep": str(self.is_final_step)})
+
         return request_dict
 
 
@@ -381,6 +388,7 @@ def step(
     spark_config: "SparkConfig" = None,
     use_spot_instances: Union[bool, PipelineVariable] = False,
     max_wait_time_in_seconds: Optional[Union[int, PipelineVariable]] = None,
+    is_final_step: Optional[bool] = False,
 ):
     """Decorator for converting a python function to a pipeline step.
 
@@ -605,6 +613,7 @@ def step(
                 spark_config=spark_config,
                 use_spot_instances=use_spot_instances,
                 max_wait_time_in_seconds=max_wait_time_in_seconds,
+                is_final_step=is_final_step,
             )
 
             return _generate_delayed_return(

--- a/src/sagemaker/workflow/lambda_step.py
+++ b/src/sagemaker/workflow/lambda_step.py
@@ -90,6 +90,7 @@ class LambdaStep(Step):
         outputs: Optional[List[LambdaOutput]] = None,
         cache_config: Optional[CacheConfig] = None,
         depends_on: Optional[List[Union[str, Step, StepCollection]]] = None,
+        is_final_step: Optional[bool] = False,
     ):
         """Constructs a LambdaStep.
 
@@ -107,6 +108,8 @@ class LambdaStep(Step):
             depends_on (List[Union[str, Step, StepCollection]]): A list of `Step`/`StepCollection`
                 names or `Step` instances or `StepCollection` instances that this `LambdaStep`
                 depends on.
+            is_final_step (bool) : Whether the step is a final step. If it is, this step is going to be
+                executed at the end of the execution, after all non-final steps finish.
         """
         super(LambdaStep, self).__init__(
             name, display_name, description, StepTypeEnum.LAMBDA, depends_on
@@ -126,6 +129,7 @@ class LambdaStep(Step):
 
         root_prop.__dict__["Outputs"] = property_dict
         self._properties = root_prop
+        self.is_final_step = is_final_step
 
     @property
     def arguments(self) -> RequestType:
@@ -142,6 +146,9 @@ class LambdaStep(Step):
         request_dict = super().to_request()
         if self.cache_config:
             request_dict.update(self.cache_config.config)
+
+        if self.is_final_step:
+            request_dict.update({"IsFinalStep": str(self.is_final_step)})
 
         function_arn = self._get_function_arn()
         request_dict["FunctionArn"] = function_arn

--- a/tests/unit/sagemaker/workflow/test_function_step.py
+++ b/tests/unit/sagemaker/workflow/test_function_step.py
@@ -85,6 +85,7 @@ def test_step_decorator(mock_job_settings):
         retry_policies=[retry_policy],
         instance_type="ml.m5.large",
         image_uri="test_image_uri",
+        is_final_step=True,
     )
     def sum(a, b, c, d):
         return a + b + c + d
@@ -109,6 +110,7 @@ def test_step_decorator(mock_job_settings):
     assert mock_job_settings.call_args[1]["image_uri"] == "test_image_uri"
     assert function_step._serialized_data.func is not None
     assert function_step._serialized_data.args is not None
+    assert function_step.is_final_step is True
 
 
 @patch("sagemaker.workflow.utilities._pipeline_config", MOCKED_PIPELINE_CONFIG)


### PR DESCRIPTION
*Description of changes:*
Add is_final_step under processing/training/lambda/function step 

*Testing done:*
Unit test that the value of is_final_step can be transferred into json when defined

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
